### PR TITLE
SEOULDATA-108 [FEATURE] 네비게이션바 생성 및 페이지 연결

### DIFF
--- a/this-is-seoul-soul/package.json
+++ b/this-is-seoul-soul/package.json
@@ -13,6 +13,7 @@
     "@react-oauth/google": "^0.12.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^5.1.0",
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {

--- a/this-is-seoul-soul/src/App.tsx
+++ b/this-is-seoul-soul/src/App.tsx
@@ -1,5 +1,8 @@
+import { Outlet } from "react-router-dom";
 import './App.css';
 import { SignIn } from './pages/Auth/SignIn';
+import { BottomTabNavigation } from "./components/organisms/BottomTabNavigation";
+import { homePage } from "./constants/pathname";
 
 export type LoginStatusType = 'init' | 'nickname' | 'festi' | 'complete';
 
@@ -9,6 +12,10 @@ export default function App() {
   return (
     <div className='w-full h-full'>
       <SignIn />
+      <div>
+        <Outlet/>
+        <BottomTabNavigation label={homePage.label} />
+      </div>
     </div>
   );
 }

--- a/this-is-seoul-soul/src/components/organisms/BottomTabNavigation.tsx
+++ b/this-is-seoul-soul/src/components/organisms/BottomTabNavigation.tsx
@@ -36,7 +36,7 @@ export const BottomTabNavigation = ({ label }: { label: string }) => {
       };
 
     return (
-        <div className="fixed bottom-0 left-0 right-0 flex w-full bg-white p-3 border border-gray-400 rounded-t-xl">
+        <div className="fixed bottom-0 left-0 right-0 m-auto w-full max-w-[500px] flex bg-white p-3 border border-gray-400 rounded-t-xl">
         {tabItems.map((item, index) => (
             
             <div

--- a/this-is-seoul-soul/src/components/organisms/BottomTabNavigation.tsx
+++ b/this-is-seoul-soul/src/components/organisms/BottomTabNavigation.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { heartPage, homePage, mapPage, myPage } from "../../constants/pathname";
 import { GoHomeFill, GoBookmarkFill, GoPersonFill } from "react-icons/go";
 import { IoMap } from "react-icons/io5";
@@ -19,37 +20,35 @@ const tabItems: TabItem[] = [
 
 
 export const BottomTabNavigation = ({ label }: { label: string }) => {
-    const [value, setValue] = useState<number | null>(null);
+  const [value, setValue] = useState<number | null>(null);
+  const navigate = useNavigate();
 
-    useEffect(() => {
-      const selectedTab = tabItems.find(item => item.label === label);
-      if (selectedTab) {
-        setValue(tabItems.indexOf(selectedTab));
-      }
-    }, [label])
+  useEffect(() => {
+    const selectedTab = tabItems.find(item => item.label === label);
+    if (selectedTab) {
+      setValue(tabItems.indexOf(selectedTab));
+    }
+  }, [label])
 
-    const handleClick = (index: number) => {
-        // 네비게이션 처리는 여기서 하세요. 예를 들어, history.push 등을 사용하여 페이지 이동 가능
-      console.log(value);
-      console.log(`Clicked on tab ${tabItems[index].label}`);
-      setValue(index);
-      };
+  const navigateToMenuPage = (index: number) => {
+    navigate(tabItems[index].path);
+    setValue(index);
+  };
 
-    return (
-        <div className="fixed bottom-0 left-0 right-0 m-auto w-full max-w-[500px] flex bg-white p-3 border border-gray-400 rounded-t-xl">
-        {tabItems.map((item, index) => (
-            
-            <div
-              key={index}
-              className="flex flex-col items-center gap-1"
-              onClick={() => handleClick(index)}
-              style={{ width: `${100 / tabItems.length}%` }}
-            >
-              <item.icon size={20} className={`${value === index ? 'text-yellow-400' : ' text-gray-400'}`} />
-              <div className={`text-xs ${value === index ? ' text-black' : ' text-gray-600'}`}>{item.label}</div>
-            </div>
-          ))}
-        </div>
-      );
+  return (
+    <div className="fixed bottom-0 left-0 right-0 m-auto w-full max-w-[500px] flex bg-white p-3 border border-gray-400 rounded-t-xl">
+      {tabItems.map((item, index) => (
+          <div
+            key={index}
+            className="flex flex-col items-center gap-1"
+            onClick={() => navigateToMenuPage(index)}
+            style={{ width: `${100 / tabItems.length}%` }}
+          >
+            <item.icon size={20} className={`${value === index ? 'text-yellow-400' : ' text-gray-400'}`} />
+            <div className={`text-xs ${value === index ? ' text-black' : ' text-gray-600'}`}>{item.label}</div>
+          </div>
+      ))}
+    </div>
+  );
 };
   

--- a/this-is-seoul-soul/src/components/organisms/BottomTabNavigation.tsx
+++ b/this-is-seoul-soul/src/components/organisms/BottomTabNavigation.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react';
+import { heartPage, homePage, mapPage, myPage } from "../../constants/pathname";
+import { GoHomeFill, GoBookmarkFill, GoPersonFill } from "react-icons/go";
+import { IoMap } from "react-icons/io5";
+import React from "react";
+
+interface TabItem {
+  label: string;
+  path: string;
+  icon: (props: React.SVGProps<SVGSVGElement> & { size?: number }) => JSX.Element;
+}
+
+const tabItems: TabItem[] = [
+  { label: homePage.label, path: homePage.path, icon: GoHomeFill },
+  { label: mapPage.label, path: mapPage.path, icon: IoMap },
+  { label: heartPage.label, path: heartPage.path, icon: GoBookmarkFill },
+  { label: myPage.label, path: myPage.path, icon: GoPersonFill }
+];
+
+
+export const BottomTabNavigation = ({ label }: { label: string }) => {
+    const [value, setValue] = useState<number | null>(null);
+
+    useEffect(() => {
+      const selectedTab = tabItems.find(item => item.label === label);
+      if (selectedTab) {
+        setValue(tabItems.indexOf(selectedTab));
+      }
+    }, [label])
+
+    const handleClick = (index: number) => {
+        // 네비게이션 처리는 여기서 하세요. 예를 들어, history.push 등을 사용하여 페이지 이동 가능
+      console.log(value);
+      console.log(`Clicked on tab ${tabItems[index].label}`);
+      setValue(index);
+      };
+
+    return (
+        <div className="fixed bottom-0 left-0 right-0 flex w-full bg-white p-3 border border-gray-400 rounded-t-xl">
+        {tabItems.map((item, index) => (
+            
+            <div
+              key={index}
+              className="flex flex-col items-center gap-1"
+              onClick={() => handleClick(index)}
+              style={{ width: `${100 / tabItems.length}%` }}
+            >
+              <item.icon size={20} className={`${value === index ? 'text-yellow-400' : ' text-gray-400'}`} />
+              <div className={`text-xs ${value === index ? ' text-black' : ' text-gray-600'}`}>{item.label}</div>
+            </div>
+          ))}
+        </div>
+      );
+};
+  

--- a/this-is-seoul-soul/src/constants/pathname.ts
+++ b/this-is-seoul-soul/src/constants/pathname.ts
@@ -1,0 +1,26 @@
+export const homePage = {
+    path: '/home',
+    label: '행사 추천',
+};
+
+export const mapPage = {
+    path: '/map',
+    label: '지도',
+};
+
+export const heartPage = {
+    path: '/heart',
+    label: '저장',
+};
+
+export const myPage = {
+    path: '/my',
+    label: 'MY',
+};
+
+export const pathname = [
+    homePage,
+    mapPage,
+    heartPage,
+    myPage
+]

--- a/this-is-seoul-soul/src/main.tsx
+++ b/this-is-seoul-soul/src/main.tsx
@@ -3,16 +3,33 @@ import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 import { RouterProvider, createBrowserRouter } from 'react-router-dom';
-import { TestPage } from './pages/TestPage.tsx';
+import { HomePage } from "./pages/HomePage.tsx";
+import { MapPage } from "./pages/MapPage.tsx";
+import { HeartPage } from "./pages/HeartPage.tsx";
+import { MyPage } from "./pages/MyPage.tsx";
 
 const router = createBrowserRouter([
   {
     path: '/',
     element: <App />,
-  },
-  {
-    path: '/test',
-    element: <TestPage />,
+    children: [
+      {
+        path: '/home',
+        element: <HomePage />,
+      },
+      {
+        path: '/map',
+        element: <MapPage />,
+      },
+      {
+        path: '/heart',
+        element: <HeartPage />,
+      },
+      {
+        path: '/my',
+        element: <MyPage />,
+      },
+    ]
   },
 ]);
 

--- a/this-is-seoul-soul/src/pages/HeartPage.tsx
+++ b/this-is-seoul-soul/src/pages/HeartPage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const HeartPage = () => {
+  return <div>HeartPage</div>;
+};

--- a/this-is-seoul-soul/src/pages/HomePage.tsx
+++ b/this-is-seoul-soul/src/pages/HomePage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const HomePage = () => {
+  return <div>HomePage</div>;
+};

--- a/this-is-seoul-soul/src/pages/MapPage.tsx
+++ b/this-is-seoul-soul/src/pages/MapPage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const MapPage = () => {
+  return <div>MapPage</div>;
+};

--- a/this-is-seoul-soul/src/pages/MyPage.tsx
+++ b/this-is-seoul-soul/src/pages/MyPage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const MyPage = () => {
+  return <div>MyPage</div>;
+};

--- a/this-is-seoul-soul/tailwind.config.js
+++ b/this-is-seoul-soul/tailwind.config.js
@@ -26,6 +26,8 @@ export default {
         800: '#424242',
         900: '#212121',
       },
+      white: '#FFFFFF',
+      black: '#000000'
     },
     extend: {},
   },


### PR DESCRIPTION
- 바텀 네비게이션바를 구현하였습니다.
- 바텀 네비게이션바의 메뉴를 누르면 네비게이션 뒤에 페이지가 해당 메뉴에 따라 바뀌게 됩니다.
- 아직 헤더 관련 코드는 없습니다.
- dev-fe에 병합되면서, URI의 / (루트경로)에 구글 로그인 화면과 바텀 네비게이션바가 함께 보이게 됩니다.
  -> 이 부분은 수정이 필요합니다. (로그인이 되면 /home으로 이동하며 바텀 네비게이션바가 표시되도록 하는 코드가 필요합니다.)
 (+) 구글 로그인 버튼 눌렀을 때 빈 화면에 머무르는데 왜 그럴까요?!
![image](https://github.com/this-is-seoul-soul/frontend-pwa/assets/56223389/31776178-0711-4f94-973e-b9abf39e709e)
