### PR TITLE
SEOULDATA-58 [FEATURE] 홈 화면, 지도 화면의 검색바 UI 생성

### DIFF
--- a/this-is-seoul-soul/src/App.tsx
+++ b/this-is-seoul-soul/src/App.tsx
@@ -21,10 +21,8 @@ export default function App() {
 
   return (
     <div className='w-full h-full'>
-      <div>
-        <Outlet />
-        <BottomTabNavigation label={label!} />
-      </div>
+      <Outlet />
+      <BottomTabNavigation label={label!} />
     </div>
   );
 }

--- a/this-is-seoul-soul/src/components/organisms/SearchBar.tsx
+++ b/this-is-seoul-soul/src/components/organisms/SearchBar.tsx
@@ -1,0 +1,3 @@
+export const SearchBar = ({ }) => {
+    return <div></div>;
+}

--- a/this-is-seoul-soul/src/components/organisms/SearchBar.tsx
+++ b/this-is-seoul-soul/src/components/organisms/SearchBar.tsx
@@ -1,19 +1,26 @@
 import { GoSearch } from "react-icons/go";
 
-export const SearchBar = ({ }) => {
+interface SearchBarProps {
+    map?: boolean;
+}
+
+/* 지도 화면 검색바는 <SearchBar map /> 으로 사용합니다. */
+export const SearchBar = ({ map = false }: SearchBarProps) => {
     return (
-        <div className="flex w-full bg-white shadow-md">
-            <div className="p-4">
-                <GoSearch
-                    size={20}
-                    className="text-yellow-400 stroke-1 stroke-yellow-400"
+        <div className={`${map ? "p-4": ""}`}>
+            <div className={`flex w-full bg-white shadow-md ${map ? "rounded-xl" : ""}`}>
+                <div className="p-4">
+                    <GoSearch
+                        size={20}
+                        className="text-yellow-400 stroke-1 stroke-yellow-400"
+                    />
+                </div>
+                <input
+                    type="text"
+                    placeholder="어떤 축제를 찾으시나요?"
+                    className=" placeholder-gray-500 w-full mr-4 text-base"
                 />
             </div>
-            <input
-                type="text"
-                placeholder="어떤 축제를 찾으시나요?"
-                className=" placeholder-gray-500 w-full mr-4 text-base"
-            />
-        </div>)
-    ;
+        </div>
+    );
 }

--- a/this-is-seoul-soul/src/components/organisms/SearchBar.tsx
+++ b/this-is-seoul-soul/src/components/organisms/SearchBar.tsx
@@ -1,3 +1,19 @@
+import { GoSearch } from "react-icons/go";
+
 export const SearchBar = ({ }) => {
-    return <div></div>;
+    return (
+        <div className="flex w-full bg-white shadow-md">
+            <div className="p-4">
+                <GoSearch
+                    size={20}
+                    className="text-yellow-400 stroke-1 stroke-yellow-400"
+                />
+            </div>
+            <input
+                type="text"
+                placeholder="어떤 축제를 찾으시나요?"
+                className=" placeholder-gray-500 w-full mr-4 text-base"
+            />
+        </div>)
+    ;
 }

--- a/this-is-seoul-soul/src/pages/Home/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/index.tsx
@@ -2,7 +2,7 @@ import { SearchBar } from "components/organisms/SearchBar";
 
 
 export const HomePage = () => {
-  return <div className="w-full h-full">
+  return <div className="w-full h-full bg-yellow-50">
     <SearchBar />
   </div>;
 };

--- a/this-is-seoul-soul/src/pages/Home/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/index.tsx
@@ -1,3 +1,8 @@
+import { SearchBar } from "components/organisms/SearchBar";
+
+
 export const HomePage = () => {
-  return <div>HomePage</div>;
+  return <div>HomePage
+    <SearchBar/>
+  </div>;
 };

--- a/this-is-seoul-soul/src/pages/Home/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/index.tsx
@@ -2,7 +2,7 @@ import { SearchBar } from "components/organisms/SearchBar";
 
 
 export const HomePage = () => {
-  return <div>HomePage
-    <SearchBar/>
+  return <div className="w-full h-full">
+    <SearchBar />
   </div>;
 };


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-58 -> dev-fe

# 변경 사항
- 홈 화면의 검색바 생성 (`<SearchBar />`으로 사용)
- 지도 화면의 검색바 생성 (`<SearchBar map />`으로 사용)
  - 지도 화면에서의 검색바를 위해 기존 홈 화면에 사용된 검색바에 props로 지도 여부를 받도록 하였습니다. 
  - map이라는 boolean 값을 받으므로, 지도 화면에서 SearchBar 컴포넌트 UI를 사용하고 싶으면 `<SearchBar map />`으로 사용하면 됩니다.
  - position: fixed나 z-index 요소가 없으므로 **실제 지도 구현시 플로팅이 필요하다면 수정해야 할 수 있습니다.**
- 아직 API는 연결되지 않았습니다.

![image](https://github.com/this-is-seoul-soul/frontend-pwa/assets/56223389/53b260ef-0fca-4052-ac2e-8dadf5f82fae)
![image](https://github.com/this-is-seoul-soul/frontend-pwa/assets/56223389/f2b9c10d-7b14-49b4-8bb9-7fa178fc124c)

