### PR TITLE
SEOULDATA-82 [FEATURE] 축제 상세 페이지 구현, 탭 메뉴 추가 (각 탭은 미완성)

### DIFF
--- a/this-is-seoul-soul/src/App.tsx
+++ b/this-is-seoul-soul/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css';
 import { BottomTabNavigation } from './components/organisms/BottomTabNavigation';
 import { pathname, signInPage } from './constants/pathname';
 import { useEffect } from 'react';
+import { TopHeader } from "components/molecules/TopHeader";
 
 export type LoginStatusType = 'init' | 'nickname' | 'festi' | 'complete';
 
@@ -21,6 +22,7 @@ export default function App() {
 
   return (
     <div className='w-full h-full'>
+      <TopHeader label={label!} />
       <Outlet />
       <BottomTabNavigation label={label!} />
     </div>

--- a/this-is-seoul-soul/src/components/atoms/festInfo/FestInfoHomeItem.tsx
+++ b/this-is-seoul-soul/src/components/atoms/festInfo/FestInfoHomeItem.tsx
@@ -22,7 +22,7 @@ export const FestInfoHomeItem = ({ fest }: FestInfoProps) => {
     };
 
     return (
-        <div className="flex flex-col p-2 bg-white gap-1" onClick={() => navigation.navigateToFestiDetail(fest.festSeq)}>
+        <div className="flex flex-col p-2 bg-white gap-1" onClick={() => navigation.navigateToFestDetail(fest.festSeq)}>
             <div id="image-container" className="relative w-full min-w-[140px] min-h-[140px] h-0 pb-[100%]">
                 <img src={image} className="absolute w-full h-full left-0 right-0 top-0 object-cover" />
             </div>

--- a/this-is-seoul-soul/src/components/molecules/TopHeader.tsx
+++ b/this-is-seoul-soul/src/components/molecules/TopHeader.tsx
@@ -1,4 +1,4 @@
-import { FestiDetailPage } from "constants/pathname";
+import { FestDetailPage } from "constants/pathname";
 import { useAtomValue } from "jotai";
 import { headerTitleAtom } from "stores/headerStore";
 import { TopHeaderBase } from "./TopHeaderBase";
@@ -12,7 +12,7 @@ export const TopHeader = ({ label }: TopHeaderProps) => {
 
     return (
         <>
-            {label === FestiDetailPage.label && <TopHeaderBase back title={headerTitle} /> }
+            {label === FestDetailPage.label && <TopHeaderBase back title={headerTitle} /> }
         </>
     );
 }

--- a/this-is-seoul-soul/src/constants/pathname.ts
+++ b/this-is-seoul-soul/src/constants/pathname.ts
@@ -38,8 +38,8 @@ export const FestiTestProsecutorPage = {
   label: 'FESTI 검사',
 };
 
-export const FestiDetailPage = {
-  path: '/festidetail',
+export const FestDetailPage = {
+  path: '/festdetail',
   label: "축제 상세",
 }
 
@@ -52,5 +52,5 @@ export const pathname = [
   mapPage,
   heartPage,
   myPage,
-  FestiDetailPage,
+  FestDetailPage,
 ];

--- a/this-is-seoul-soul/src/hooks/useAppNavigation.tsx
+++ b/this-is-seoul-soul/src/hooks/useAppNavigation.tsx
@@ -3,7 +3,7 @@ import {
   FestiTestLandingPage,
   FestiTestProsecutorPage,
   signInPage,
-  FestiDetailPage,
+  FestDetailPage,
 } from 'constants/pathname';
 import { createSearchParams, useNavigate } from 'react-router-dom';
 
@@ -31,21 +31,21 @@ export const useAppNavigation = () => {
   };
 
   // 축제 아이템 상세 화면
-  const navigateToFestiDetail = (festSeq: number) => {
+  const navigateToFestDetail = (festSeq: number) => {
     navigate({
-      pathname: FestiDetailPage.path,
+      pathname: FestDetailPage.path,
       search: createSearchParams({
         festSeq: `${festSeq}`
       }).toString()
     });
-
   };
+
 
   return {
     navigateToSignIn,
     navigateToCheckNickname,
     navigateToFestiTestLanding,
     navigateToFestiTestProsecutor,
-    navigateToFestiDetail,
+    navigateToFestDetail,
   };
 };

--- a/this-is-seoul-soul/src/main.tsx
+++ b/this-is-seoul-soul/src/main.tsx
@@ -51,7 +51,7 @@ const router = createBrowserRouter([
         element: <MyPage />,
       },
       {
-        path: '/festidetail',
+        path: '/festdetail',
         element: <FestDetailPage />,
       }
     ],

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/TabHomePage.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/TabHomePage.tsx
@@ -1,0 +1,9 @@
+interface Props {}
+
+export const TabHomePage = ({} : Props) => {
+    return (
+        <div>
+            탭 홈
+        </div>
+    );
+}

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/TabMapPage.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/TabMapPage.tsx
@@ -1,0 +1,9 @@
+interface Props {}
+
+export const TabMapPage = ({} : Props) => {
+    return (
+        <div>
+            탭 지도
+        </div>
+    );
+}

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/TabReviewPage.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/TabReviewPage.tsx
@@ -1,0 +1,9 @@
+interface Props {}
+
+export const TabReviewPage = ({} : Props) => {
+    return (
+        <div>
+            탭 리뷰
+        </div>
+    );
+}

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
@@ -3,6 +3,7 @@ import { useSetAtom } from "jotai";
 import { useSearchParams } from "react-router-dom";
 import { headerTitleAtom } from "stores/headerStore";
 import { festDetail } from "types/festDetail";
+import { GoBookmark, GoBookmarkFill, GoShareAndroid, GoStarFill } from "react-icons/go";
 
 interface Props {}
 
@@ -42,9 +43,39 @@ export const FestDetailPage = ({ }: Props) => {
 
     return (
         <div>
-            <img src={fest.mainImg} alt="" />
-            <section><div>fef</div></section>
-            <section><div>fefe</div></section>            
+            <div className="w-full h-32 overflow-hidden">
+                <img src={fest.mainImg} alt="" />
+            </div>
+            <section>
+                <div className="flex flex-col p-4">
+                    <div className="flex justify-end gap-2">
+                        <GoShareAndroid size={24} className=" text-gray-600"/>
+                        <GoBookmark size={24} className=" text-gray-600"/>
+                    </div>
+                    <div className="flex flex-col justify-center items-center">
+                        <div className="text-xl font-extrabold">{fest.title}</div>
+                        <div className="pt-1 text-gray-600">{fest.codename}</div>
+                        <div className="pt-4 flex items-center gap-2">
+                        <div className="flex flex-wrap justify-start items-center gap-4">
+                            <div>{ fest.isContinue ? "진행중" : "미진행"}</div>
+                            <div className="flex items-center gap-1">
+                                <GoStarFill className="fill-yellow-400" />
+                                {fest.avgPoint}
+                            </div>
+                            <div className="flex items-center gap-1">
+                                <div>리뷰</div>
+                                <div>{fest.cntReview >= 50 ? '50+' : `${fest.cntReview}`}</div>
+                            </div>
+                                <div className="flex items-center gap-1">
+                                    <GoBookmarkFill className="fill-yellow-400" />
+                                    {fest.tag[0]?.cnt}
+                            </div>
+                        </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <section><div></div></section>            
         </div>
     );
 }

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
@@ -1,9 +1,13 @@
-import { TopHeader } from "components/molecules/TopHeader";
 import { useSetAtom } from "jotai";
 import { useSearchParams } from "react-router-dom";
 import { headerTitleAtom } from "stores/headerStore";
 import { festDetail } from "types/festDetail";
 import { GoBookmark, GoBookmarkFill, GoShareAndroid, GoStarFill } from "react-icons/go";
+import { useState } from "react";
+import { TabHomePage } from "./TabHomePage";
+import { TabReviewPage } from "./TabReviewPage";
+import { TabMapPage } from "./TabMapPage";
+import { tabItemType } from "types/tab";
 
 interface Props {}
 
@@ -34,12 +38,26 @@ const fest : festDetail = {
     ]
 }
 
+
+
+const tabs = [
+    { label: '홈', component: <TabHomePage /> },
+    { label: '리뷰', component: <TabReviewPage /> },
+    { label: '지도', component: <TabMapPage /> },
+];
+
 export const FestDetailPage = ({ }: Props) => {
     const [searchParams] = useSearchParams();
-    const setHeaderTitle = useSetAtom(headerTitleAtom); 
     const param = searchParams.get('festSeq') || "";
     const festSeq = parseInt(param);
+    
+    const setHeaderTitle = useSetAtom(headerTitleAtom); 
     setHeaderTitle(fest.title);
+
+    const [activeTab, setActiveTab] = useState<tabItemType>(tabs[0]);
+    const handleTabClick = (tab: tabItemType) => {
+        setActiveTab(tab);
+    };
 
     return (
         <div>
@@ -47,7 +65,7 @@ export const FestDetailPage = ({ }: Props) => {
                 <img src={fest.mainImg} alt="" />
             </div>
             <section>
-                <div className="flex flex-col p-4">
+                <div className="flex flex-col p-4 pb-8">
                     <div className="flex justify-end gap-2">
                         <GoShareAndroid size={24} className=" text-gray-600"/>
                         <GoBookmark size={24} className=" text-gray-600"/>
@@ -75,7 +93,20 @@ export const FestDetailPage = ({ }: Props) => {
                     </div>
                 </div>
             </section>
-            <section><div></div></section>            
+            <section>
+                <div className={`grid grid-cols-${tabs.length} border-b-2`}>
+                    {tabs.map((tab, id) => (
+                        <div
+                            key={id}
+                            className={`w-1/2 text-center mx-auto py-2 ${activeTab.label === tab.label ? 'font-extrabold border-b border-b-black' : ''}`}
+                            onClick={() => handleTabClick(tab)}
+                        >
+                            {tab.label}
+                        </div>
+                    ))}
+                </div>
+                {activeTab?.component}
+            </section>            
         </div>
     );
 }

--- a/this-is-seoul-soul/src/types/tab.d.ts
+++ b/this-is-seoul-soul/src/types/tab.d.ts
@@ -1,0 +1,4 @@
+export type tabItemType = {
+    label: string
+    component: React.ReactNode
+}


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-82 -> dev-fe

# 변경 사항
- 상단 헤더 코드 누락된 부분 함께 추가
- 축제 상세 페이지 이미지, 중앙 정보, 탭 메뉴 구현
- 각 탭의 페이지는 아직 미완성

![image](https://github.com/this-is-seoul-soul/frontend-pwa/assets/56223389/dc029e21-5859-4a00-bec0-bf512fc5472f)
