### PR TITLE
SEOULDATA-60 [FEATURE] 축제 상세 페이지 홈 탭 구현

### DIFF
--- a/this-is-seoul-soul/src/App.tsx
+++ b/this-is-seoul-soul/src/App.tsx
@@ -13,12 +13,12 @@ export default function App() {
 
   const navigate = useNavigate();
 
-  // useEffect(() => {
-  //   const isInitialRoute = localStorage.getItem('isInitialRoute');
-  //   if (isInitialRoute !== 'F') {
-  //     navigate(signInPage.path, { replace: true });
-  //   }
-  // }, [navigate]);
+  useEffect(() => {
+    const isInitialRoute = localStorage.getItem('isInitialRoute');
+    if (isInitialRoute !== 'F') {
+      navigate(signInPage.path, { replace: true });
+    }
+  }, [navigate]);
 
   return (
     <div className='w-full h-full'>

--- a/this-is-seoul-soul/src/App.tsx
+++ b/this-is-seoul-soul/src/App.tsx
@@ -13,12 +13,12 @@ export default function App() {
 
   const navigate = useNavigate();
 
-  useEffect(() => {
-    const isInitialRoute = localStorage.getItem('isInitialRoute');
-    if (isInitialRoute !== 'F') {
-      navigate(signInPage.path, { replace: true });
-    }
-  }, [navigate]);
+  // useEffect(() => {
+  //   const isInitialRoute = localStorage.getItem('isInitialRoute');
+  //   if (isInitialRoute !== 'F') {
+  //     navigate(signInPage.path, { replace: true });
+  //   }
+  // }, [navigate]);
 
   return (
     <div className='w-full h-full'>

--- a/this-is-seoul-soul/src/components/atoms/festInfo/FestInfoHomeItem.tsx
+++ b/this-is-seoul-soul/src/components/atoms/festInfo/FestInfoHomeItem.tsx
@@ -18,7 +18,7 @@ export const FestInfoHomeItem = ({ fest }: FestInfoProps) => {
 
     const handleHeart = async (event: React.MouseEvent) => {
         // TODO: 찜 추가/취소 api 연결
-        event.stopPropagation () 
+        event.stopPropagation(); 
         setIsHeart(!isHeart);
     };
 
@@ -31,7 +31,7 @@ export const FestInfoHomeItem = ({ fest }: FestInfoProps) => {
                 <div className={`${codeColor} rounded-lg text-xs px-2 py-1`}>
                     {fest.codeName}
                 </div>
-                <div className="" onClick={(e) => handleHeart(e)}>
+                <div onClick={(e) => handleHeart(e)}>
                     {isHeart == true ? (
                         <GoBookmarkFill  size={"1.25rem"} className="  fill-yellow-400"/>
                     ) : (

--- a/this-is-seoul-soul/src/components/atoms/festInfo/FestInfoHomeItem.tsx
+++ b/this-is-seoul-soul/src/components/atoms/festInfo/FestInfoHomeItem.tsx
@@ -16,9 +16,10 @@ export const FestInfoHomeItem = ({ fest }: FestInfoProps) => {
     const image = fest.mainImg || Default;
     const navigation = useAppNavigation();
 
-    const handleHeart = async () => {
-    // TODO: 찜 추가/취소 api 연결
-    setIsHeart(!isHeart);
+    const handleHeart = async (event: React.MouseEvent) => {
+        // TODO: 찜 추가/취소 api 연결
+        event.stopPropagation () 
+        setIsHeart(!isHeart);
     };
 
     return (
@@ -30,7 +31,7 @@ export const FestInfoHomeItem = ({ fest }: FestInfoProps) => {
                 <div className={`${codeColor} rounded-lg text-xs px-2 py-1`}>
                     {fest.codeName}
                 </div>
-                <div className="relative" onClick={handleHeart}>
+                <div className="" onClick={(e) => handleHeart(e)}>
                     {isHeart == true ? (
                         <GoBookmarkFill  size={"1.25rem"} className="  fill-yellow-400"/>
                     ) : (

--- a/this-is-seoul-soul/src/components/molecules/TopHeaderBase.tsx
+++ b/this-is-seoul-soul/src/components/molecules/TopHeaderBase.tsx
@@ -11,7 +11,7 @@ export const TopHeaderBase = ({ back = false, title}: BaseTopHeaderProps) => {
 
     return (
         <div className="relative h-[47px]">
-            <div className="fixed left-0 right-0  grid grid-cols-3 px-5 py-3 bg-red-100">
+            <div className="fixed left-0 right-0  grid grid-cols-3 px-5 py-3 bg-white">
                 <div className="justify-self-start">
                     {back ? <div onClick={() => { navigate(-1) }}><IoIosArrowBack size={24} /></div> : <></>}
                 </div>

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/TabHomePage.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/TabHomePage.tsx
@@ -1,9 +1,38 @@
-interface Props {}
+import { festDetail } from "types/festDetail";
+import { GoLocation, GoPerson  } from "react-icons/go";
+import { MdAccessTime } from "react-icons/md";
+import { FaWonSign, FaLink } from "react-icons/fa6";
 
-export const TabHomePage = ({} : Props) => {
+interface TabHomePageProps {
+    fest: festDetail
+}
+
+export const TabHomePage = ({ fest } : TabHomePageProps) => {
     return (
-        <div>
-            탭 홈
+        <div className="p-4 px-6 flex flex-col gap-5">
+            <div className="flex items-start gap-2">
+                <div><GoLocation size={18} className="mt-1 text-gray-600 stroke-1 stroke-gray-600"/></div>
+                <span>{fest.guname} {fest.place}</span>
+            </div>
+            <div className="flex items-start gap-2">
+            <div><GoPerson size={18} className="mt-1 text-gray-600 stroke-1 stroke-gray-600"/></div>
+                <span className="font-bold">{fest.isContinue ? "진행중" : "미진행"}</span>
+                <span id="period" className="text-gray-800">
+                    {fest.startDate} ~ {fest.endDate}
+                </span>
+            </div>
+            <div className="flex items-start gap-2">
+            <div><MdAccessTime size={18} className="mt-1 text-gray-600 stroke-1 stroke-gray-600"/></div>
+                <span>{fest.isFree}</span>
+            </div>
+            <div className="flex items-start gap-2">
+            <div><FaWonSign size={17} className="mt-1 text-gray-600 "/></div>
+                <span>{fest.useTrgt}</span>
+            </div>
+            <div className="flex items-start gap-2 break-all">
+            <div><FaLink size={18} className="mt-1 text-gray-600 stroke-1 stroke-gray-600"/></div>
+                <p className=" text-blue"><a href={fest.orgLink}>{fest.orgLink}</a></p>
+            </div>
         </div>
     );
 }

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
@@ -41,7 +41,7 @@ const fest : festDetail = {
 
 
 const tabs = [
-    { label: '홈', component: <TabHomePage /> },
+    { label: '홈', component: <TabHomePage fest={fest} /> },
     { label: '리뷰', component: <TabReviewPage /> },
     { label: '지도', component: <TabMapPage /> },
 ];
@@ -75,35 +75,32 @@ export const FestDetailPage = ({ }: Props) => {
                     <div className="flex justify-end gap-2">
                         <GoShareAndroid size={24} className=" text-gray-600"/>
                         <div onClick={(e) => handleHeart(e)}>
-                        {isHeart == true ? (
-                            <GoBookmarkFill size={24} className=" fill-yellow-400"/>
-                        ) : (
-                            <GoBookmark size={24} className=" text-gray-400 " />
+                            {isHeart == true ? (
+                                <GoBookmarkFill size={24} className=" fill-yellow-400"/>
+                            ) : (
+                                <GoBookmark size={24} className=" text-gray-400 " />
                             )}
                         </div>
-                    
                     </div>
-                </div>
-                <div>
                     <div className="flex flex-col justify-center items-center">
                         <div className="text-xl font-extrabold">{fest.title}</div>
                         <div className="pt-1 text-gray-600">{fest.codename}</div>
                         <div className="pt-4 flex items-center gap-2">
-                        <div className="flex flex-wrap justify-start items-center gap-4">
-                            <div>{ fest.isContinue ? "진행중" : "미진행"}</div>
-                            <div className="flex items-center gap-1">
-                                <GoStarFill className="fill-yellow-400" />
-                                {fest.avgPoint}
-                            </div>
-                            <div className="flex items-center gap-1">
-                                <div>리뷰</div>
-                                <div>{fest.cntReview >= 50 ? '50+' : `${fest.cntReview}`}</div>
-                            </div>
+                            <div className="flex flex-wrap justify-start items-center gap-4">
+                                <div>{ fest.isContinue ? "진행중" : "미진행"}</div>
                                 <div className="flex items-center gap-1">
-                                    <GoBookmarkFill className="fill-yellow-400" />
-                                    {fest.tag[0]?.cnt}
+                                    <GoStarFill className="fill-yellow-400" />
+                                    {fest.avgPoint}
+                                </div>
+                                <div className="flex items-center gap-1">
+                                    <div>리뷰</div>
+                                    <div>{fest.cntReview >= 50 ? '50+' : `${fest.cntReview}`}</div>
+                                </div>
+                                    <div className="flex items-center gap-1">
+                                        <GoBookmarkFill className="fill-yellow-400" />
+                                        {fest.tag[0]?.cnt}
+                                </div>
                             </div>
-                        </div>
                         </div>
                     </div>
                 </div>

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
@@ -59,6 +59,12 @@ export const FestDetailPage = ({ }: Props) => {
         setActiveTab(tab);
     };
 
+    const [isHeart, setIsHeart] = useState(fest.isHeart);
+    const handleHeart = async (event: React.MouseEvent) => {
+        // TODO: 찜 추가/취소 api 연결
+        setIsHeart(!isHeart);
+    };
+
     return (
         <div>
             <div className="w-full h-32 overflow-hidden">
@@ -68,8 +74,17 @@ export const FestDetailPage = ({ }: Props) => {
                 <div className="flex flex-col p-4 pb-8">
                     <div className="flex justify-end gap-2">
                         <GoShareAndroid size={24} className=" text-gray-600"/>
-                        <GoBookmark size={24} className=" text-gray-600"/>
+                        <div onClick={(e) => handleHeart(e)}>
+                        {isHeart == true ? (
+                            <GoBookmarkFill size={24} className=" fill-yellow-400"/>
+                        ) : (
+                            <GoBookmark size={24} className=" text-gray-400 " />
+                            )}
+                        </div>
+                    
                     </div>
+                </div>
+                <div>
                     <div className="flex flex-col justify-center items-center">
                         <div className="text-xl font-extrabold">{fest.title}</div>
                         <div className="pt-1 text-gray-600">{fest.codename}</div>

--- a/this-is-seoul-soul/tailwind.config.js
+++ b/this-is-seoul-soul/tailwind.config.js
@@ -62,6 +62,7 @@ export default {
       },
       white: '#FFFFFF',
       black: '#000000',
+      blue: '#2F49A5',
     },
     extend: {},
   },


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [x] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-60 -> dev-fe

# 변경 사항
- 축제 상세 페이지의 홈 탭 구현
- 축제 상세 페이지 북마크에 이벤트 적용
- 헤더 색 수정
![image](https://github.com/this-is-seoul-soul/frontend-pwa/assets/56223389/1e12bbed-b138-4905-a6c8-182939328f77)

