### PR TITLE
SEOULDATA-110 [FEATURE] 축제 상세 페이지 리뷰 탭 구현 (리뷰 아이템 미완성)

### DIFF
--- a/this-is-seoul-soul/src/components/atoms/titles/TitleReviewSection.tsx
+++ b/this-is-seoul-soul/src/components/atoms/titles/TitleReviewSection.tsx
@@ -1,0 +1,17 @@
+interface TitleSectionProps {
+    title: string
+    description: string
+}
+
+export const TitleSection = ({title, description} : TitleSectionProps) => {
+    return (
+        <div>
+            <div className="text-lg font-bold">
+                {title}
+            </div>
+            <div className="text-sm text-gray-800">
+                {description}
+            </div>
+        </div>
+    );
+}

--- a/this-is-seoul-soul/src/components/molecules/ListHeader.tsx
+++ b/this-is-seoul-soul/src/components/molecules/ListHeader.tsx
@@ -1,13 +1,19 @@
+import { IoIosArrowDown } from "react-icons/io";
+
 interface ListHeaderProps {
     total?: number
+    sort?:boolean
 }
 
-export const ListHeader = ({ total } : ListHeaderProps) => {
+export const ListHeader = ({ total, sort = false } : ListHeaderProps) => {
     return (
-        <div className="flex justify-between items-center px-4 bg-white">
-            <div>
+        <div className="flex justify-between items-center px-6 bg-white">
+            {total ? <div>
                 총 <span className=" text-yellow-400 font-bold">{total}</span>개
-            </div>
+            </div> : <div></div>}
+            {sort && <div className="flex items-center">
+                추천순 <IoIosArrowDown className="mt-1 pl-1" />
+            </div>}
         </div>
     );
 }

--- a/this-is-seoul-soul/src/components/molecules/TopHeaderBase.tsx
+++ b/this-is-seoul-soul/src/components/molecules/TopHeaderBase.tsx
@@ -10,8 +10,8 @@ export const TopHeaderBase = ({ back = false, title}: BaseTopHeaderProps) => {
     const navigate = useNavigate();
 
     return (
-        <div className="relative h-[47px]">
-            <div className="fixed left-0 right-0  grid grid-cols-3 px-5 py-3 bg-white">
+        <div className="relative  h-[47px]">
+            <div className="fixed max-w-[500px] left-0 right-0 mx-auto grid grid-cols-3 px-5 py-3 bg-white">
                 <div className="justify-self-start">
                     {back ? <div onClick={() => { navigate(-1) }}><IoIosArrowBack size={24} /></div> : <></>}
                 </div>

--- a/this-is-seoul-soul/src/components/organisms/festDetail/TabHome.tsx
+++ b/this-is-seoul-soul/src/components/organisms/festDetail/TabHome.tsx
@@ -3,11 +3,11 @@ import { GoLocation, GoPerson  } from "react-icons/go";
 import { MdAccessTime } from "react-icons/md";
 import { FaWonSign, FaLink } from "react-icons/fa6";
 
-interface TabHomePageProps {
+interface TabHomeProps {
     fest: festDetail
 }
 
-export const TabHomePage = ({ fest } : TabHomePageProps) => {
+export const TabHome = ({ fest } : TabHomeProps) => {
     return (
         <div className="p-4 px-6 flex flex-col gap-5">
             <div className="flex items-start gap-2">

--- a/this-is-seoul-soul/src/components/organisms/festDetail/TabMap.tsx
+++ b/this-is-seoul-soul/src/components/organisms/festDetail/TabMap.tsx
@@ -1,6 +1,6 @@
 interface Props {}
 
-export const TabMapPage = ({} : Props) => {
+export const TabMap = ({} : Props) => {
     return (
         <div>
             탭 지도

--- a/this-is-seoul-soul/src/components/organisms/festDetail/TabReview.tsx
+++ b/this-is-seoul-soul/src/components/organisms/festDetail/TabReview.tsx
@@ -4,11 +4,11 @@ import { festDetail } from "types/festDetail";
 import { GoStar, GoStarFill  } from "react-icons/go";
 import { useState } from "react";
 
-interface TabReviewPageProps {
+interface TabReviewProps {
     fest: festDetail
 }
 
-export const TabReviewPage = ({ fest }: TabReviewPageProps) => {
+export const TabReview = ({ fest }: TabReviewProps) => {
     const [rating, setRating] = useState<number>(0);
 
     const handleStarClick = (starNumber: number) => {

--- a/this-is-seoul-soul/src/components/organisms/festDetail/TabReview.tsx
+++ b/this-is-seoul-soul/src/components/organisms/festDetail/TabReview.tsx
@@ -3,16 +3,19 @@ import { ListHeader } from "components/molecules/ListHeader";
 import { festDetail } from "types/festDetail";
 import { GoStar, GoStarFill  } from "react-icons/go";
 import { useState } from "react";
+import { useAppNavigation } from "hooks/useAppNavigation";
 
 interface TabReviewProps {
     fest: festDetail
 }
 
 export const TabReview = ({ fest }: TabReviewProps) => {
+    const navigator = useAppNavigation();
     const [rating, setRating] = useState<number>(0);
 
     const handleStarClick = (starNumber: number) => {
         setRating(starNumber);
+        navigator.navigateToReviewCreate(starNumber, fest.festSeq);
     };
 
     const maxStars = 5;

--- a/this-is-seoul-soul/src/constants/pathname.ts
+++ b/this-is-seoul-soul/src/constants/pathname.ts
@@ -43,6 +43,11 @@ export const FestDetailPage = {
   label: "축제 상세",
 }
 
+export const ReviewCreatePage = {
+  path: '/festdetail/review',
+  label: "리뷰 등록",
+}
+
 export const pathname = [
   signInPage,
   CheckNicknamePage,
@@ -53,4 +58,5 @@ export const pathname = [
   heartPage,
   myPage,
   FestDetailPage,
+  ReviewCreatePage,
 ];

--- a/this-is-seoul-soul/src/constants/review.ts
+++ b/this-is-seoul-soul/src/constants/review.ts
@@ -1,0 +1,22 @@
+export const goodList = [
+    {
+        goodId: 0,
+        label: "주차가 편해요"
+    },
+    {
+        goodId: 1,
+        label: "직원이 친절해요"
+    },
+    {
+        goodId: 2,
+        label: "가성비가 좋아요"
+    },
+    {
+        goodId: 3,
+        label: "특별한 날 가기 좋아요"
+    },
+    {
+        goodId: 4,
+        label: "깨끗해요"
+    },
+]

--- a/this-is-seoul-soul/src/hooks/useAppNavigation.tsx
+++ b/this-is-seoul-soul/src/hooks/useAppNavigation.tsx
@@ -4,6 +4,7 @@ import {
   FestiTestProsecutorPage,
   signInPage,
   FestDetailPage,
+  ReviewCreatePage,
 } from 'constants/pathname';
 import { createSearchParams, useNavigate } from 'react-router-dom';
 
@@ -40,6 +41,21 @@ export const useAppNavigation = () => {
     });
   };
 
+  // 리뷰 등록 화면
+  const navigateToReviewCreate = (rating: number, festSeq: number) => {
+    navigate(
+      {
+        pathname: ReviewCreatePage.path,
+        search: createSearchParams({
+          festSeq: `${festSeq}`
+        }).toString()
+      },
+      {
+        state: { rating: rating }
+      }
+    );
+  };
+
 
   return {
     navigateToSignIn,
@@ -47,5 +63,6 @@ export const useAppNavigation = () => {
     navigateToFestiTestLanding,
     navigateToFestiTestProsecutor,
     navigateToFestDetail,
+    navigateToReviewCreate,
   };
 };

--- a/this-is-seoul-soul/src/main.tsx
+++ b/this-is-seoul-soul/src/main.tsx
@@ -12,6 +12,7 @@ import { MapPage } from 'pages/Map/index.tsx';
 import { HeartPage } from 'pages/Heart/index.tsx';
 import { MyPage } from 'pages/My/index.tsx';
 import { FestDetailPage } from "pages/Home/FestDetail/index.tsx";
+import { ReviewCreatePage } from "pages/Home/FestDetail/ReviewCreate/index.tsx";
 
 const router = createBrowserRouter([
   {
@@ -53,7 +54,11 @@ const router = createBrowserRouter([
       {
         path: '/festdetail',
         element: <FestDetailPage />,
-      }
+      },
+      {
+        path: '/festdetail/review',
+        element: <ReviewCreatePage />,
+      },
     ],
   },
 ]);

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/ReviewCreate/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/ReviewCreate/index.tsx
@@ -1,0 +1,33 @@
+import { useLocation, useSearchParams } from "react-router-dom";
+
+interface Props {}
+
+/* Request Dto
+{
+    “content”: “정말 좋아요”,
+    “point”: 5,
+    “imgUrl”: [ “image1.jpg”, “image2.jpg” ],
+    “tag”: [1, 2, 4],
+    “festSeq”: 2
+}
+*/
+
+export const ReviewCreatePage = ({ }: Props) => {
+    const location = useLocation();
+    let { rating } = location.state;
+    const [searchParams] = useSearchParams();
+    const param = searchParams.get('festSeq') || "";
+    const festSeq = parseInt(param);
+    
+
+    console.log(location)
+    console.log(location.state)
+
+    return (
+        <div>
+            리뷰 등록 페이지
+            별점: {rating}
+            festSeq: { festSeq}
+        </div>
+    );
+}

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/TabHomePage.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/TabHomePage.tsx
@@ -15,18 +15,18 @@ export const TabHomePage = ({ fest } : TabHomePageProps) => {
                 <span>{fest.guname} {fest.place}</span>
             </div>
             <div className="flex items-start gap-2">
-            <div><GoPerson size={18} className="mt-1 text-gray-600 stroke-1 stroke-gray-600"/></div>
+            <div><MdAccessTime size={18} className="mt-1 text-gray-600 stroke-1 stroke-gray-600"/></div>
                 <span className="font-bold">{fest.isContinue ? "진행중" : "미진행"}</span>
                 <span id="period" className="text-gray-800">
                     {fest.startDate} ~ {fest.endDate}
                 </span>
             </div>
             <div className="flex items-start gap-2">
-            <div><MdAccessTime size={18} className="mt-1 text-gray-600 stroke-1 stroke-gray-600"/></div>
+            <div><FaWonSign size={18} className="mt-1 text-gray-600 "/></div>
                 <span>{fest.isFree}</span>
             </div>
             <div className="flex items-start gap-2">
-            <div><FaWonSign size={17} className="mt-1 text-gray-600 "/></div>
+            <div><GoPerson size={18} className="mt-1 text-gray-600 stroke-1 stroke-gray-600"/></div>
                 <span>{fest.useTrgt}</span>
             </div>
             <div className="flex items-start gap-2 break-all">

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/TabReviewPage.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/TabReviewPage.tsx
@@ -1,9 +1,29 @@
-interface Props {}
+import { TitleSection } from "components/atoms/titles/TitleReviewSection";
+import { ListHeader } from "components/molecules/ListHeader";
+import { festDetail } from "types/festDetail";
 
-export const TabReviewPage = ({} : Props) => {
+interface TabReviewPageProps {
+    fest: festDetail
+}
+
+export const TabReviewPage = ({ fest } : TabReviewPageProps) => {
     return (
         <div>
-            탭 리뷰
+            <section className="p-4">
+                <TitleSection title="이런 점이 좋았어요!" description={`총 ${fest.cntReview}명 참여`} />
+            </section>
+            <section className="p-4">
+                <TitleSection title={fest.title} description="다녀오셨나요? 리뷰를 남겨보세요." />
+            </section>
+            <section>
+                <div className="p-4">
+                    <TitleSection title="리뷰" description={`평점 ${fest.avgPoint}\u00A0  총 ${fest.cntReview}개`} />
+                </div>
+                <ListHeader sort />
+                <div>
+
+                </div>
+            </section>
         </div>
     );
 }

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/TabReviewPage.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/TabReviewPage.tsx
@@ -9,9 +9,9 @@ interface TabReviewPageProps {
 export const TabReviewPage = ({ fest } : TabReviewPageProps) => {
     return (
         <div>
-            <section className="p-4">
+            {/* <section className="p-4">
                 <TitleSection title="이런 점이 좋았어요!" description={`총 ${fest.cntReview}명 참여`} />
-            </section>
+            </section> */}
             <section className="p-4">
                 <TitleSection title={fest.title} description="다녀오셨나요? 리뷰를 남겨보세요." />
             </section>

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/TabReviewPage.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/TabReviewPage.tsx
@@ -1,28 +1,44 @@
 import { TitleSection } from "components/atoms/titles/TitleReviewSection";
 import { ListHeader } from "components/molecules/ListHeader";
 import { festDetail } from "types/festDetail";
+import { GoStar, GoStarFill  } from "react-icons/go";
+import { useState } from "react";
 
 interface TabReviewPageProps {
     fest: festDetail
 }
 
-export const TabReviewPage = ({ fest } : TabReviewPageProps) => {
+export const TabReviewPage = ({ fest }: TabReviewPageProps) => {
+    const [rating, setRating] = useState<number>(0);
+
+    const handleStarClick = (starNumber: number) => {
+        setRating(starNumber);
+    };
+
+    const maxStars = 5;
+    let stars = [];
+
+    for (let i = 1; i <= maxStars; i++) {
+        stars.push(
+            <span key={i} onClick={() => handleStarClick(i)}>
+                {i <= rating ? <GoStarFill size={32} className="text-yellow-400" /> : <GoStar size={32} className="text-gray-400" />}
+            </span>
+        );
+    }
     return (
         <div>
             {/* <section className="p-4">
                 <TitleSection title="이런 점이 좋았어요!" description={`총 ${fest.cntReview}명 참여`} />
             </section> */}
-            <section className="p-4">
+            <section className="p-4 bg-gray-100">
                 <TitleSection title={fest.title} description="다녀오셨나요? 리뷰를 남겨보세요." />
+                <div className="flex justify-center gap-1 pt-5 pb-4">{stars}</div>
             </section>
             <section>
                 <div className="p-4">
                     <TitleSection title="리뷰" description={`평점 ${fest.avgPoint}\u00A0  총 ${fest.cntReview}개`} />
                 </div>
                 <ListHeader sort />
-                <div>
-
-                </div>
             </section>
         </div>
     );

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
@@ -4,9 +4,9 @@ import { headerTitleAtom } from "stores/headerStore";
 import { festDetail } from "types/festDetail";
 import { GoBookmark, GoBookmarkFill, GoShareAndroid, GoStarFill } from "react-icons/go";
 import { useState } from "react";
-import { TabHomePage } from "./TabHomePage";
-import { TabReviewPage } from "./TabReviewPage";
-import { TabMapPage } from "./TabMapPage";
+import { TabHome } from "../../../components/organisms/festDetail/TabHome";
+import { TabReview } from "../../../components/organisms/festDetail/TabReview";
+import { TabMap } from "../../../components/organisms/festDetail/TabMap";
 import { tabItemType } from "types/tab";
 
 interface Props {}
@@ -41,9 +41,9 @@ const fest : festDetail = {
 
 
 const tabs = [
-    { label: '홈', component: <TabHomePage fest={fest} /> },
-    { label: '리뷰', component: <TabReviewPage fest={fest} /> },
-    { label: '지도', component: <TabMapPage /> },
+    { label: '홈', component: <TabHome fest={fest} /> },
+    { label: '리뷰', component: <TabReview fest={fest} /> },
+    { label: '지도', component: <TabMap /> },
 ];
 
 export const FestDetailPage = ({ }: Props) => {

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
@@ -42,7 +42,7 @@ const fest : festDetail = {
 
 const tabs = [
     { label: '홈', component: <TabHomePage fest={fest} /> },
-    { label: '리뷰', component: <TabReviewPage /> },
+    { label: '리뷰', component: <TabReviewPage fest={fest} /> },
     { label: '지도', component: <TabMapPage /> },
 ];
 

--- a/this-is-seoul-soul/src/pages/Home/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/index.tsx
@@ -106,7 +106,7 @@ export const HomePage = () => {
       {/* TODO: 배너 */}
     </section>
     <section>
-      <div className="pl-4 pt-9 pb-3 bg-white">{nickname}님<br /><b>이런 축제는 어떤가요?</b></div>
+      <div className="pl-6 pt-9 pb-3 text-lg bg-white">{nickname}님,<br /><b>이런 축제는 어떤가요?</b></div>
       <div className="pl-2 pb-8 bg-white flex overflow-x-auto">
         {FestDummy.length > 0 &&
           FestDummy.map((fest, index) => (
@@ -117,7 +117,7 @@ export const HomePage = () => {
       </div>
     </section>
     <section>
-      <div className="pl-4 pt-9 pb-3 bg-white"><b>원하시는 축제</b>를 만나보세요!</div>
+      <div className="pl-6 pt-9 pb-3 text-lg bg-white"><b>원하시는 축제</b>를 만나보세요!</div>
       <ListHeader total={24} />
       <div className={`grid grid-cols-2 gap-4 p-5 pb-24 bg-white`}>
         {FestDummy.length > 0 &&


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-110 -> dev-fe

# 변경 사항
- 리뷰 탭 레이아웃 작성 및 UI 구현
- 리뷰 등록 페이지 생성 및 연결
- 아직 리뷰 아이템은 없습니다

![image](https://github.com/this-is-seoul-soul/frontend-pwa/assets/56223389/6f7c822b-7eda-4d3b-9cd2-99af0932c4ef)
