### PR TITLE
SEOULDATA-113 [FEATURE] 축제 상세 페이지 탭 - 지도 구현

### DIFF
--- a/this-is-seoul-soul/src/components/atoms/buttons/BottomButton2.tsx
+++ b/this-is-seoul-soul/src/components/atoms/buttons/BottomButton2.tsx
@@ -1,0 +1,27 @@
+import { cls } from 'utils/cls';
+
+export interface BottomButton2Props {
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  title: string;
+  type?: ButtonType;
+  color?: string;
+  disabled?: boolean;
+}
+
+export type ButtonType = 'submit' | 'reset' | 'button' | undefined;
+
+export const BottomButton2 = ({ onClick, title, type, color, disabled = false }: BottomButton2Props) => {
+  return (
+    <div className={cls('font-bold text-xl w-full left-0 bottom-12 px-4 pb-4')}>
+      <button
+        type={type}
+        onClick={onClick}
+        className={cls(`w-full ${disabled ? 'bg-gray-200' : 'bg-yellow-200 '} rounded-2xl p-3`)}
+        color={color}
+        disabled={disabled}
+      >
+        {title}
+      </button>
+    </div>
+  );
+};

--- a/this-is-seoul-soul/src/components/atoms/titles/TitleReviewSection.tsx
+++ b/this-is-seoul-soul/src/components/atoms/titles/TitleReviewSection.tsx
@@ -1,6 +1,6 @@
 interface TitleSectionProps {
     title: string
-    description: string
+    description?: string
 }
 
 export const TitleSection = ({title, description} : TitleSectionProps) => {

--- a/this-is-seoul-soul/src/components/molecules/ReviewCreateGoodList/ReviewCreateGoodList.tsx
+++ b/this-is-seoul-soul/src/components/molecules/ReviewCreateGoodList/ReviewCreateGoodList.tsx
@@ -1,0 +1,40 @@
+import { goodList } from 'constants/review';
+import { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+import { cls } from 'utils/cls';
+
+export const ReviewCreateGoodList = () => {
+  const { setValue } = useFormContext();
+  const [selectedGoods, setSelectedGoods] = useState<number[]>([]);
+
+  const handleGoodItem = (goodId: number) => {
+    const updatedSelected = selectedGoods.includes(goodId)
+      ? selectedGoods.filter((id) => id !== goodId)
+      : [...selectedGoods, goodId];
+
+    setSelectedGoods(updatedSelected);
+    setValue('tag', updatedSelected);
+  };
+
+  return (
+    <div className="flex flex-col gap-2 py-6">
+      {goodList.map((item) => {
+        return (
+          <div
+            key={item.goodId}
+            className={cls(
+              `w-full text-center py-2 rounded-lg ${
+                selectedGoods.includes(item.goodId)
+                  ? 'text-gray-900 border border-yellow-400 bg-yellow-50'
+                  : ' text-gray-600 border border-gray-400'
+              }`
+            )}
+            onClick={() => handleGoodItem(item.goodId)}
+          >
+            {item.label}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/this-is-seoul-soul/src/components/molecules/TopHeader.tsx
+++ b/this-is-seoul-soul/src/components/molecules/TopHeader.tsx
@@ -5,8 +5,6 @@ import {
   SettingPage,
   ReviewCreatePage,
 } from 'constants/pathname';
-import { useAtomValue } from 'jotai';
-import { headerTitleAtom } from 'stores/headerStore';
 import { TopHeaderBase } from './TopHeaderBase';
 
 interface TopHeaderProps {

--- a/this-is-seoul-soul/src/components/molecules/TopHeader.tsx
+++ b/this-is-seoul-soul/src/components/molecules/TopHeader.tsx
@@ -5,22 +5,22 @@ import {
   SettingPage,
   ReviewCreatePage,
 } from 'constants/pathname';
-import { useAtomValue } from "jotai";
-import { headerTitleAtom } from "stores/headerStore";
-import { TopHeaderBase } from "./TopHeaderBase";
+import { useAtomValue } from 'jotai';
+import { headerTitleAtom } from 'stores/headerStore';
+import { TopHeaderBase } from './TopHeaderBase';
 
 interface TopHeaderProps {
   label: string;
 }
 
 export const TopHeader = ({ label }: TopHeaderProps) => {
-  const headerTitle = useAtomValue(headerTitleAtom);
+  // const headerTitle = useAtomValue(headerTitleAtom);
 
   return (
     <>
-      {label === FestDetailPage.label && <TopHeaderBase back title={headerTitle} />}
-      {label === ReviewCreatePage.label && <TopHeaderBase back title={headerTitle} />}
-      {(label === SettingPage.label ||
+      {(label === FestDetailPage.label ||
+        label === ReviewCreatePage.label ||
+        label === SettingPage.label ||
         label === MyReviewDetailsPage.label ||
         label === FestivalRegisterPage.label) && <TopHeaderBase back title={label} />}
     </>

--- a/this-is-seoul-soul/src/components/molecules/TopHeaderBase.tsx
+++ b/this-is-seoul-soul/src/components/molecules/TopHeaderBase.tsx
@@ -1,5 +1,7 @@
+import { useAtomValue } from 'jotai';
 import { IoIosArrowBack } from 'react-icons/io';
 import { useNavigate } from 'react-router-dom';
+import { headerTitleAtom } from 'stores/headerStore';
 import { cls } from 'utils/cls';
 
 interface BaseTopHeaderProps {
@@ -7,28 +9,37 @@ interface BaseTopHeaderProps {
   title?: string;
 }
 
-export const TopHeaderBase = ({ back = false, title }: BaseTopHeaderProps) => {
+export const TopHeaderBase = ({ back = false, title = '' }: BaseTopHeaderProps) => {
+  const headerTitle = useAtomValue(headerTitleAtom);
   const navigate = useNavigate();
   console.log(title);
 
   return (
-    <div className={cls('relative z-20', `${title !== '축제 등록' && 'h-[47px]'}`)}>
-      <div className='fixed max-w-[500px] left-0 right-0 mx-auto grid grid-cols-3 px-2 py-3 bg-white'>
-        <div className='justify-self-start'>
+    // <div className={cls('relative z-20', `${title !== '축제 등록' && 'h-[47px]'}`)}>
+    <div
+      className={cls(
+        'relative z-20',
+        `${['축제 등록', '축제 상세'].includes(title) ? '' : 'h-[47px]'}`
+      )}
+    >
+      <div className="fixed max-w-[500px] left-0 right-0 mx-auto grid grid-cols-3 px-2 py-3 bg-white">
+        <div className="justify-self-start">
           {back ? (
             <div
               onClick={() => {
                 navigate(-1);
               }}
             >
-              <IoIosArrowBack size={24} className='text-gray-800' />
+              <IoIosArrowBack size={24} className="text-gray-800" />
             </div>
           ) : (
             <></>
           )}
         </div>
-        <div className='justify-self-center font-bold text-gray-900'>{title}</div>
-        <div className='justify-self-end'></div>
+        <div className="justify-self-center font-bold text-gray-900">
+          {['축제 상세', '리뷰 등록'].includes(title) ? headerTitle : title}
+        </div>
+        <div className="justify-self-end"></div>
       </div>
     </div>
   );

--- a/this-is-seoul-soul/src/components/organisms/festDetail/TabMap.tsx
+++ b/this-is-seoul-soul/src/components/organisms/festDetail/TabMap.tsx
@@ -1,9 +1,16 @@
-interface Props {}
+import { festDetail } from 'types/festDetail';
+import { Map, MapMarker } from 'react-kakao-maps-sdk';
 
-export const TabMap = ({} : Props) => {
-    return (
-        <div>
-            탭 지도
-        </div>
-    );
+interface TabMapProps {
+  fest: festDetail;
 }
+
+export const TabMap = ({ fest }: TabMapProps) => {
+  const markerPosition = { lat: fest.lot, lng: fest.lat };
+
+  return (
+    <Map center={markerPosition} className="w-full h-full flex-grow" level={3}>
+      <MapMarker position={markerPosition} />
+    </Map>
+  );
+};

--- a/this-is-seoul-soul/src/components/organisms/festDetail/TabReview.tsx
+++ b/this-is-seoul-soul/src/components/organisms/festDetail/TabReview.tsx
@@ -61,7 +61,7 @@ export const TabReview = ({ fest }: TabReviewProps) => {
                 <TitleSection title="이런 점이 좋았어요!" description={`총 ${fest.cntReview}명 참여`} />
                 <div className='py-4'>
                     {dummyTags?.tag.map((item) => {
-                        return <TagBar index={item.tag} tagTotal={dummyTags.total} tag={item.tag} cnt={item.cnt} />
+                        return <div key={item.tag}><TagBar index={item.tag} tagTotal={dummyTags.total} tag={item.tag} cnt={item.cnt} /></div>
                     })}
                 </div>
                 

--- a/this-is-seoul-soul/src/components/organisms/festDetail/TabReview.tsx
+++ b/this-is-seoul-soul/src/components/organisms/festDetail/TabReview.tsx
@@ -1,12 +1,39 @@
 import { TitleSection } from "components/atoms/titles/TitleReviewSection";
 import { ListHeader } from "components/molecules/ListHeader";
-import { festDetail } from "types/festDetail";
+import { festDetail, reviewTagList } from "types/festDetail";
 import { GoStar, GoStarFill  } from "react-icons/go";
 import { useState } from "react";
 import { useAppNavigation } from "hooks/useAppNavigation";
+import { TagBar } from 'components/atoms/reviewInfo/TagBar';
 
 interface TabReviewProps {
     fest: festDetail
+}
+
+const dummyTags : reviewTagList = {
+    "total": 12,
+    "tag": [
+        {
+            "tag": 0,
+            "cnt": 4
+        },
+        {
+            "tag": 1,
+            "cnt": 3
+        },
+        {
+            "tag": 2,
+            "cnt": 2
+        },
+        {
+            "tag": 3,
+            "cnt": 1
+        },
+        {
+            "tag": 4,
+            "cnt": 0
+        },
+    ]
 }
 
 export const TabReview = ({ fest }: TabReviewProps) => {
@@ -30,9 +57,15 @@ export const TabReview = ({ fest }: TabReviewProps) => {
     }
     return (
         <div>
-            {/* <section className="p-4">
+            <section className="p-4">
                 <TitleSection title="이런 점이 좋았어요!" description={`총 ${fest.cntReview}명 참여`} />
-            </section> */}
+                <div className='py-4'>
+                    {dummyTags?.tag.map((item) => {
+                        return <TagBar index={item.tag} tagTotal={dummyTags.total} tag={item.tag} cnt={item.cnt} />
+                    })}
+                </div>
+                
+            </section>
             <section className="p-4 bg-gray-100">
                 <TitleSection title={fest.title} description="다녀오셨나요? 리뷰를 남겨보세요." />
                 <div className="flex justify-center gap-1 pt-5 pb-4">{stars}</div>

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/ReviewCreate/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/ReviewCreate/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import { GoStar, GoStarFill } from 'react-icons/go';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { MdAddAPhoto } from 'react-icons/md';
@@ -7,7 +7,6 @@ import { TitleSection } from 'components/atoms/titles/TitleReviewSection';
 import { ReviewCreateGoodList } from 'components/molecules/ReviewCreateGoodList/ReviewCreateGoodList';
 import { BottomButton2 } from 'components/atoms/buttons/BottomButton2';
 import { useForm, FormProvider } from 'react-hook-form';
-import { goodList } from 'constants/review';
 
 /* Request Dto
 {
@@ -22,32 +21,28 @@ import { goodList } from 'constants/review';
 interface FormData {
   content: string;
   point: number;
+  imgUrl: Array<string>;
   tag: Array<number>;
 }
 
 export const ReviewCreatePage = () => {
-  const navigation = useAppNavigation();
   const MAX_LENGTH = 10;
-  // let [inputCount, setInputCount] = useState(0);
+  const STARS = [1, 2, 3, 4, 5];
+  const navigation = useAppNavigation();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const param = searchParams.get('festSeq') || '';
   const festSeq = parseInt(param);
 
-  // const [rating, setRating] = useState<number>(location.state.rating);
   const methods = useForm<FormData>({
     defaultValues: {
       point: location.state.rating,
       content: '',
+      imgUrl: [],
       tag: [],
     },
   });
   const { register, handleSubmit, setValue, watch } = methods;
-
-  // const handleStarClick = (starNumber: number) => {
-  //   // setRating(starNumber);
-  //   setValue('point', starNumber);
-  // };
 
   const handleContent = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const text = event.target.value;
@@ -55,12 +50,21 @@ export const ReviewCreatePage = () => {
       return;
     }
     setValue('content', text);
-    // setInputCount(text.length);
   };
 
-  useEffect(() => {
-    console.log(watch());
-  }, [watch()]);
+  const [imgUrls, setImgUrls] = useState<string[]>([]);
+  const handleImageUpload = (event: ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files) {
+      const file = event.target.files[0];
+      const updatedImgUrls = imgUrls.concat(URL.createObjectURL(file));
+      setImgUrls(updatedImgUrls);
+      setValue('imgUrl', [...watch('imgUrl'), file.name]);
+    }
+  };
+
+  // useEffect(() => {
+  //   console.log(watch());
+  // }, [watch()]);
 
   const onSubmit = (data: any) => {
     // TODO: 리뷰 등록 api 연결
@@ -68,15 +72,13 @@ export const ReviewCreatePage = () => {
     navigation.navigateToFestDetail(festSeq);
   };
 
-  const starArr = [1, 2, 3, 4, 5];
-
   return (
     <FormProvider {...methods}>
       <form onSubmit={handleSubmit(onSubmit)}>
         <section>
           <div className="flex flex-col items-center gap-2 pt-16">
             <div className="flex justify-center gap-1">
-              {starArr.map((starNum) => (
+              {STARS.map((starNum) => (
                 <span key={starNum} onClick={() => setValue('point', starNum)}>
                   {starNum <= watch('point') ? (
                     <GoStarFill size={52} className="text-yellow-400" />
@@ -94,34 +96,28 @@ export const ReviewCreatePage = () => {
 
         <section className="pt-8 px-8 flex">
           <div className="w-[76px] min-w-[76px] h-[76px] flex justify-center items-center mr-1 bg-white border border-yellow-400 rounded-lg">
-            <MdAddAPhoto size={36} className="text-yellow-400 mr-[4px]" />
+            <label htmlFor="photo">
+              <MdAddAPhoto size={36} className="text-yellow-400 mr-[4px]" />
+            </label>
+            <input
+              id="photo"
+              type="file"
+              accept="image/*"
+              onChange={handleImageUpload}
+              className="hidden"
+            />
           </div>
-          <div className="flex gap-1 overflow-x-auto whitespace-nowrap scrollbar-hide">
-            <img
-              className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
-              src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp"
-              alt=""
-            />
-            <img
-              className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
-              src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp"
-              alt=""
-            />
-            <img
-              className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
-              src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp"
-              alt=""
-            />
-            <img
-              className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
-              src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp"
-              alt=""
-            />
-            <img
-              className="w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
-              src="https://img.kbs.co.kr/kbs/620/news.kbs.co.kr/data/fckeditor/new/image/2024/04/01/169771711958787915.jpg"
-              alt=""
-            />
+          <div className="flex flex-row-reverse gap-1 overflow-x-auto whitespace-nowrap scrollbar-hide">
+            {imgUrls.map((item, idx) => {
+              return (
+                <img
+                  key={idx}
+                  className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
+                  src={item}
+                  alt=""
+                />
+              );
+            })}
           </div>
         </section>
 

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/ReviewCreate/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/ReviewCreate/index.tsx
@@ -1,11 +1,13 @@
-import { ChangeEvent, useState } from "react";
-import { GoStar, GoStarFill } from "react-icons/go";
-import { useLocation, useSearchParams } from "react-router-dom";
-import { MdAddAPhoto } from "react-icons/md";
-import { BottomButton } from "components/atoms/buttons/BottomButton";
-import { useAppNavigation } from "hooks/useAppNavigation";
-
-interface Props {}
+import { ChangeEvent, useEffect, useState } from 'react';
+import { GoStar, GoStarFill } from 'react-icons/go';
+import { useLocation, useSearchParams } from 'react-router-dom';
+import { MdAddAPhoto } from 'react-icons/md';
+import { useAppNavigation } from 'hooks/useAppNavigation';
+import { TitleSection } from 'components/atoms/titles/TitleReviewSection';
+import { ReviewCreateGoodList } from 'components/molecules/ReviewCreateGoodList/ReviewCreateGoodList';
+import { BottomButton2 } from 'components/atoms/buttons/BottomButton2';
+import { useForm, FormProvider } from 'react-hook-form';
+import { goodList } from 'constants/review';
 
 /* Request Dto
 {
@@ -17,77 +19,139 @@ interface Props {}
 }
 */
 
-export const ReviewCreatePage = ({ }: Props) => {
-    const navigation = useAppNavigation();
-    const MAX_LENGTH = 1000;
-    let [inputCount, setInputCount] = useState(0);
-    const location = useLocation();
-    // let { rating } = location.state;
-    const [searchParams] = useSearchParams();
-    const param = searchParams.get('festSeq') || "";
-    const festSeq = parseInt(param);
-    
-    const [rating, setRating] = useState<number>(location.state.rating);
-
-    const handleStarClick = (starNumber: number) => {
-        setRating(starNumber);
-    };
-
-    const handleReviewText = (event:ChangeEvent<HTMLTextAreaElement>) => {
-        const text = event.target.value;
-        if (text.length > MAX_LENGTH) {
-            return
-        }
-        
-        setInputCount(text.length);
-    }
-
-    const handleRegistReview = () => {
-        // TODO: 리뷰 등록 api 연결
-        navigation.navigateToFestDetail(festSeq);
-    }
-
-    const maxStars = 5;
-    let stars = [];
-
-    for (let i = 1; i <= maxStars; i++) {
-        stars.push(
-            <span key={i} onClick={() => handleStarClick(i)}>
-                {i <= rating ? <GoStarFill size={52} className="text-yellow-400" /> : <GoStar size={52} className="text-gray-300" />}
-            </span>
-        );
-    }
-
-    return (
-        <div>
-            {/* festSeq: {festSeq} */}
-            <section>
-                <div className="flex flex-col items-center gap-2 pt-16">
-                    <div className="flex justify-center gap-1">{stars}</div>
-                    <div className="text-xl"><span className="font-bold">{rating}</span> / 5</div>
-                </div>
-            </section>
-            <section className="pt-8 px-8 flex">
-                <div className="w-[76px] min-w-[76px] h-[76px] flex justify-center items-center mr-1 bg-white border border-yellow-400 rounded-lg">
-                    <MdAddAPhoto size={36} className="text-yellow-400 mr-[4px]" />
-                </div>
-                <div className="flex gap-1 overflow-x-auto whitespace-nowrap scrollbar-hide">
-                    <img className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg" src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp" alt="" />
-                    <img className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg" src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp" alt="" />
-                    <img className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg" src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp" alt="" />
-                    <img className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg" src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp" alt="" />
-                    <img className="w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg" src="https://img.kbs.co.kr/kbs/620/news.kbs.co.kr/data/fckeditor/new/image/2024/04/01/169771711958787915.jpg" alt="" />               
-                </div>
-            </section>
-            <section className="px-8 py-4">
-                <textarea onChange={handleReviewText} maxLength={MAX_LENGTH} placeholder="리뷰를 작성하세요." className="p-4 w-full h-56 border border-gray-500 rounded-lg focus:outline-none  focus-visible:border-yellow-400 resize-none" />
-                <div className="flex justify-end text-gray-500">
-                    <span>{inputCount}</span>
-                    <span>/{MAX_LENGTH} 자</span>
-                </div>
-            </section>
-            
-            <BottomButton title="완료" type="button" onClick={handleRegistReview} disabled={ inputCount <= 0 ? true : false}/>
-        </div>
-    );
+interface FormData {
+  content: string;
+  point: number;
+  tag: Array<number>;
 }
+
+export const ReviewCreatePage = () => {
+  const navigation = useAppNavigation();
+  const MAX_LENGTH = 10;
+  // let [inputCount, setInputCount] = useState(0);
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const param = searchParams.get('festSeq') || '';
+  const festSeq = parseInt(param);
+
+  // const [rating, setRating] = useState<number>(location.state.rating);
+  const methods = useForm<FormData>({
+    defaultValues: {
+      point: location.state.rating,
+      content: '',
+      tag: [],
+    },
+  });
+  const { register, handleSubmit, setValue, watch } = methods;
+
+  // const handleStarClick = (starNumber: number) => {
+  //   // setRating(starNumber);
+  //   setValue('point', starNumber);
+  // };
+
+  const handleContent = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const text = event.target.value;
+    if (text.length > MAX_LENGTH) {
+      return;
+    }
+    setValue('content', text);
+    // setInputCount(text.length);
+  };
+
+  useEffect(() => {
+    console.log(watch());
+  }, [watch()]);
+
+  const onSubmit = (data: any) => {
+    // TODO: 리뷰 등록 api 연결
+    console.log('완료!', data);
+    navigation.navigateToFestDetail(festSeq);
+  };
+
+  const starArr = [1, 2, 3, 4, 5];
+
+  return (
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <section>
+          <div className="flex flex-col items-center gap-2 pt-16">
+            <div className="flex justify-center gap-1">
+              {starArr.map((starNum) => (
+                <span key={starNum} onClick={() => setValue('point', starNum)}>
+                  {starNum <= watch('point') ? (
+                    <GoStarFill size={52} className="text-yellow-400" />
+                  ) : (
+                    <GoStar size={52} className="text-gray-300" />
+                  )}
+                </span>
+              ))}
+            </div>
+            <div className="text-xl">
+              <span className="font-bold">{watch('point')}</span> / 5
+            </div>
+          </div>
+        </section>
+
+        <section className="pt-8 px-8 flex">
+          <div className="w-[76px] min-w-[76px] h-[76px] flex justify-center items-center mr-1 bg-white border border-yellow-400 rounded-lg">
+            <MdAddAPhoto size={36} className="text-yellow-400 mr-[4px]" />
+          </div>
+          <div className="flex gap-1 overflow-x-auto whitespace-nowrap scrollbar-hide">
+            <img
+              className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
+              src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp"
+              alt=""
+            />
+            <img
+              className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
+              src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp"
+              alt=""
+            />
+            <img
+              className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
+              src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp"
+              alt=""
+            />
+            <img
+              className=" w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
+              src="https://i.namu.wiki/i/alELF6s0wKly1dUXn2vjdDYFbOjrxITYnTEEHAB-1cNqjwOT56cOT8QTNdzPqWTndhqH2ZkTt-YAkVMmkOveiWfXG8MDhDbzvU5dgUjiDsRdvI-KYLm4_JNO96-PiPevkQsBFJr-XObx1BGfL3COog.webp"
+              alt=""
+            />
+            <img
+              className="w-[76px] h-[76px] object-cover border-2 border-gray-200 rounded-lg"
+              src="https://img.kbs.co.kr/kbs/620/news.kbs.co.kr/data/fckeditor/new/image/2024/04/01/169771711958787915.jpg"
+              alt=""
+            />
+          </div>
+        </section>
+
+        <section className="px-8 py-4">
+          <textarea
+            {...register('content', {
+              required: true,
+            })}
+            value={watch('content')}
+            onChange={handleContent}
+            placeholder="리뷰를 작성하세요."
+            className="p-4 w-full h-56 border border-gray-500 rounded-lg focus:outline-none  focus-visible:border-yellow-400 resize-none"
+          />
+          <div className="flex justify-end text-gray-500">
+            <span>{watch('content')?.length}</span>
+            <span>/{MAX_LENGTH} 자</span>
+          </div>
+        </section>
+
+        <section className="p-8">
+          <TitleSection title="어떤 점이 좋았나요?" description="1개 이상 선택해주세요" />
+          <ReviewCreateGoodList />
+        </section>
+
+        <BottomButton2
+          title="완료"
+          type="submit"
+          disabled={watch('content').length === 0 || watch('tag').length === 0 ? true : false}
+        />
+      </form>
+    </FormProvider>
+  );
+};

--- a/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
+++ b/this-is-seoul-soul/src/pages/Home/FestDetail/index.tsx
@@ -42,7 +42,7 @@ const fest: festDetail = {
 const tabs = [
   { label: '홈', component: <TabHome fest={fest} /> },
   { label: '리뷰', component: <TabReview fest={fest} /> },
-  { label: '지도', component: <TabMap /> },
+  { label: '지도', component: <TabMap fest={fest} /> },
 ];
 
 export const FestDetailPage = () => {
@@ -68,38 +68,38 @@ export const FestDetailPage = () => {
   };
 
   return (
-    <div>
-      <div className='w-full h-32 overflow-hidden'>
-        <img src={fest.mainImg} alt='' />
+    <div className="w-full min-h-full pt-[47px] flex flex-col">
+      <div className="w-full h-32 overflow-hidden">
+        <img src={fest.mainImg} alt="" />
       </div>
       <section>
-        <div className='flex flex-col p-4 pb-8'>
-          <div className='flex justify-end gap-2'>
-            <GoShareAndroid size={24} className=' text-gray-600' />
+        <div className="flex flex-col p-4 pb-8">
+          <div className="flex justify-end gap-2">
+            <GoShareAndroid size={24} className=" text-gray-600" />
             <div onClick={(e) => handleHeart(e)}>
               {isHeart == true ? (
-                <GoBookmarkFill size={24} className=' fill-yellow-400' />
+                <GoBookmarkFill size={24} className=" fill-yellow-400" />
               ) : (
-                <GoBookmark size={24} className=' text-gray-400 ' />
+                <GoBookmark size={24} className=" text-gray-400 " />
               )}
             </div>
           </div>
-          <div className='flex flex-col justify-center items-center'>
-            <div className='text-xl font-extrabold'>{fest.title}</div>
-            <div className='pt-1 text-gray-600'>{fest.codename}</div>
-            <div className='pt-4 flex items-center gap-2'>
-              <div className='flex flex-wrap justify-start items-center gap-4'>
+          <div className="flex flex-col justify-center items-center">
+            <div className="text-xl font-extrabold">{fest.title}</div>
+            <div className="pt-1 text-gray-600">{fest.codename}</div>
+            <div className="pt-4 flex items-center gap-2">
+              <div className="flex flex-wrap justify-start items-center gap-4">
                 <div>{fest.isContinue ? '진행중' : '미진행'}</div>
-                <div className='flex items-center gap-1'>
-                  <GoStarFill className='fill-yellow-400' />
+                <div className="flex items-center gap-1">
+                  <GoStarFill className="fill-yellow-400" />
                   {fest.avgPoint}
                 </div>
-                <div className='flex items-center gap-1'>
+                <div className="flex items-center gap-1">
                   <div>리뷰</div>
                   <div>{fest.cntReview >= 50 ? '50+' : `${fest.cntReview}`}</div>
                 </div>
-                <div className='flex items-center gap-1'>
-                  <GoBookmarkFill className='fill-yellow-400' />
+                <div className="flex items-center gap-1">
+                  <GoBookmarkFill className="fill-yellow-400" />
                   {fest.tag[0]?.cnt}
                 </div>
               </div>
@@ -121,8 +121,8 @@ export const FestDetailPage = () => {
             </div>
           ))}
         </div>
-        {activeTab?.component}
       </section>
+      {activeTab?.component}
     </div>
   );
 };

--- a/this-is-seoul-soul/src/types/festDetail.d.ts
+++ b/this-is-seoul-soul/src/types/festDetail.d.ts
@@ -19,3 +19,8 @@ export type festDetail = {
     isHeart: boolean,
     tag: [ { tag: int, cnt: int } ]
 }
+
+export type reviewTagList = {
+    total: number,
+    tag: { tag: number, cnt: number }[]
+}


### PR DESCRIPTION
# PR 타입
- [x] 기능 추가
- [ ] 기능 수정
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

# 반영 브랜치
> feat/SEOULDATA-113 -> dev-fe

# 변경 사항
- 리뷰 등록 페이지
  - '이런 점이 좋았어요' UI 삽입, form과 useForm을 사용하여 리팩터링, 사진 추가 가능하도록 구현
- 축제 상세 페이지
  - 지도 탭에 kakao map을 불러오고, 축제 장소에 마커를 표시하도록 구현하였습니다.
  - 구현 중, 부모 div의 높이와 관련해 지도의 높이가 0이 되어 부모 div에 flex 및 기타 높이 속성이 추가되었습니다
  - 부모 div의 스타일이 변경되며 fixed인 상단 헤더와 높이 관련 스타일 문제가 생겨 상단 헤더의 스타일도 변경되었습니다. (스타일에서 해당 페이지에 조건을 추가하는 형태로, 다른 페이지에는 지장이 없습니다)
![image](https://github.com/this-is-seoul-soul/frontend-pwa/assets/56223389/d30e4bef-f3ba-4a29-9ac2-bda4ab76e0cd)
![image](https://github.com/this-is-seoul-soul/frontend-pwa/assets/56223389/c73575ed-adb3-4c01-b5d4-a7da9c7cc9d5)
![image](https://github.com/this-is-seoul-soul/frontend-pwa/assets/56223389/4c31c56c-acf1-4464-b5db-ed42a62654b4)
